### PR TITLE
Upgrade dry-system to 0.10.x

### DIFF
--- a/dry-system-rails.gemspec
+++ b/dry-system-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'dry-system', '~> 0.5'
+  spec.add_runtime_dependency 'dry-system', '~> 0.10'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/dry/system/rails.rb
+++ b/lib/dry/system/rails.rb
@@ -40,6 +40,9 @@ module Dry
         end
 
         def finalize!
+          if app_namespace.const_defined?(:Container)
+            app_namespace.send(:remove_const, :Container)
+          end
           app_namespace.const_set(:Container, container)
           container.config.name = name
           container.finalize!

--- a/lib/dry/system/rails/version.rb
+++ b/lib/dry/system/rails/version.rb
@@ -1,7 +1,7 @@
 module Dry
   module System
     module Rails
-      VERSION = '0.0.2'.freeze
+      VERSION = '0.1.0'.freeze
     end
   end
 end

--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -14,8 +14,5 @@ Rails.application.config.action_controller.forgery_protection_origin_check = tru
 # Previous versions had false.
 ActiveSupport.to_time_preserves_timezone = true
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
-
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }

--- a/spec/dummy/config/system/boot/persistence.rb
+++ b/spec/dummy/config/system/boot/persistence.rb
@@ -1,3 +1,3 @@
-Dummy::Container.finalize(:persistence) do |container|
+Dummy::Container.boot(:persistence) do |container|
   container.register('persistence.db', :i_am_db)
 end


### PR DESCRIPTION
As the title describes this PR updates the dependency on `dry-system` to version 0.10.x. 

In addition to that, I have added a change to unset the constant when Rails is reloaded to silence `warning: already initialized constant: Container`. 