### PR TITLE
CI: Extend and update matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: ruby
-sudo: false
 cache: bundler
 bundler_args: --without console
 script:
   - bundle exec rake spec
   - RAILS_ENV=production bundle exec rspec --tag production_env
 rvm:
-  - 2.3.4
+  - 2.6.1
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
 notifications:
   email: false
   webhooks:


### PR DESCRIPTION
This PR extends the build matrix to more Ruby versions, and drops an unused Travis setting.