### PR TITLE
ActiveSupport::Reloader support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 tmp/
 .idea/
 Gemfile.lock
+.byebug_history

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp/
 .idea/
 Gemfile.lock
 .byebug_history
+spec/dummy/.bundle

--- a/lib/dry/system/rails.rb
+++ b/lib/dry/system/rails.rb
@@ -1,5 +1,5 @@
-require 'dry/system/container'
 require 'rails/railtie'
+require 'dry/system/rails/container'
 
 module Dry
   module System
@@ -21,7 +21,7 @@ module Dry
       def self.create_container(defaults)
         auto_register = defaults.auto_register
 
-        container = Class.new(Dry::System::Container).configure do |config|
+        container = Class.new(Container).configure do |config|
           config.root = ::Rails.root
           config.system_dir = config.root.join('config/system')
           config.auto_register = auto_register
@@ -44,7 +44,11 @@ module Dry
             app_namespace.send(:remove_const, :Container)
           end
           app_namespace.const_set(:Container, container)
+
+          app_namespace.send(:remove_const, :Import) if app_namespace.const_defined?(:Import)
+          app_namespace.const_set(:Import, injector)
           container.config.name = name
+
           container.finalize!(freeze: !::Rails.env.test?)
         end
 
@@ -65,6 +69,10 @@ module Dry
 
         def container
           Railtie.config.container
+        end
+
+        def injector
+          Railtie.config.injector
         end
       end
     end

--- a/lib/dry/system/rails.rb
+++ b/lib/dry/system/rails.rb
@@ -42,11 +42,10 @@ module Dry
         end
 
         def finalize!
-          app_namespace.send(:remove_const, :Container) if app_namespace.const_defined?(:Container)
-          app_namespace.const_set(:Container, container)
+          reload(:Container)
 
-          app_namespace.send(:remove_const, :Import) if app_namespace.const_defined?(:Import)
-          app_namespace.const_set(:Import, injector)
+          reload(:Import)
+
           container.config.name = name
 
           container.finalize!(freeze: !::Rails.env.test?)
@@ -71,8 +70,13 @@ module Dry
           Railtie.config.container
         end
 
-        def injector
-          Railtie.config.injector
+        def import
+          container.injector
+        end
+
+        def reload(const_name)
+          app_namespace.__send__(:remove_const, const_name) if app_namespace.const_defined?(const_name)
+          app_namespace.const_set(const_name, __send__(const_name.to_s.underscore))
         end
       end
     end

--- a/lib/dry/system/rails.rb
+++ b/lib/dry/system/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/railtie'
 require 'dry/system/rails/container'
 
@@ -21,11 +23,11 @@ module Dry
       def self.create_container(defaults)
         auto_register = defaults.auto_register
 
-        container = Class.new(Container).configure do |config|
+        container = Class.new(Container).configure { |config|
           config.root = ::Rails.root
           config.system_dir = config.root.join('config/system')
           config.auto_register = auto_register
-        end
+        }
 
         container.load_paths!('lib', 'app', 'app/models')
       end
@@ -35,14 +37,12 @@ module Dry
           System::Rails.configure
         end
 
-        config.to_prepare do |*args|
+        config.to_prepare do |*_args|
           Railtie.finalize!
         end
 
         def finalize!
-          if app_namespace.const_defined?(:Container)
-            app_namespace.send(:remove_const, :Container)
-          end
+          app_namespace.send(:remove_const, :Container) if app_namespace.const_defined?(:Container)
           app_namespace.const_set(:Container, container)
 
           app_namespace.send(:remove_const, :Import) if app_namespace.const_defined?(:Import)

--- a/lib/dry/system/rails.rb
+++ b/lib/dry/system/rails.rb
@@ -45,9 +45,13 @@ module Dry
           reload(:Container)
 
           container.config.name = name
-          container.finalize!(freeze: !::Rails.env.test?)
+          container.finalize!(freeze: freeze?)
 
           reload(:Import)
+        end
+
+        def freeze?
+          !::Rails.env.test?
         end
 
         def name

--- a/lib/dry/system/rails/container.rb
+++ b/lib/dry/system/rails/container.rb
@@ -4,11 +4,13 @@ module Dry
   module System
     module Rails
       class Container < System::Container
-        # Use `require_dependency` to make code reloading work
-        #
-        # @api private
-        def self.require_path(path)
-          require_dependency(path)
+        class << self
+          # Use `require_dependency` to make code reloading work
+          #
+          # @api private
+          def require_path(path)
+            require_dependency(path)
+          end
         end
       end
     end

--- a/lib/dry/system/rails/container.rb
+++ b/lib/dry/system/rails/container.rb
@@ -1,0 +1,16 @@
+require 'dry/system/container'
+
+module Dry
+  module System
+    module Rails
+      class Container < System::Container
+        # Use `require_dependency` to make code reloading work
+        #
+        # @api private
+        def self.require_path(path)
+          require_dependency(path)
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/models/user_repo.rb
+++ b/spec/dummy/app/models/user_repo.rb
@@ -1,5 +1,3 @@
-require 'import'
-
 class UserRepo
   include Dummy::Import['persistence.db']
 end

--- a/spec/dummy/config/system/import.rb
+++ b/spec/dummy/config/system/import.rb
@@ -1,3 +1,0 @@
-module Dummy
-  Import = Container.injector
-end

--- a/spec/integration/railtie_spec.rb
+++ b/spec/integration/railtie_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Dry::System::Rails::Railtie do
+  subject(:railtie) do
+    Dry::System::Rails::Railtie.instance
+  end
+
+  describe '.finalize!' do
+    let(:container) do
+      railtie.container
+    end
+
+    let(:import) do
+      railtie.import
+    end
+
+    it 'reloads container and import module' do
+      container.register(:foo, Object.new)
+
+      railtie.finalize!
+
+      expect(container.keys).to_not include(:foo)
+
+      klass = Class.new
+      klass.include(import['operations.create_user'])
+
+      obj = klass.new
+
+      expect(obj.create_user).to be_instance_of(Operations::CreateUser)
+    end
+  end
+end


### PR DESCRIPTION
[WIP] Contains monkey patches that enable support for `ActiveSupport::Reloader` as well as documentation on how to inject Framework components into custom objects. 