### PR TITLE
Update to dry-system-0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ rvm:
   - 2.6.3
   - 2.5.5
   - 2.4.6
-  - 2.3.8
   - truffleruby
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ E.g. You have an object `CreateWidget` that needs to process widgets asynchronou
 
 ```ruby
 # config/initializer/system.rb
-Dry::System::Rails.configure do |config|
+Dry::System::Rails.container do
+  # changes `self` to the container
   config.auto_register << 'lib'
 end
 

--- a/dry-system-rails.gemspec
+++ b/dry-system-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'dry-system', '~> 0.10'
+  spec.add_runtime_dependency 'dry-system', '~> 0.12'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/dry-system-rails.gemspec
+++ b/dry-system-rails.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '~> 2.4'
 
   spec.add_runtime_dependency 'dry-system', '~> 0.12'
 

--- a/lib/dry/system/rails/version.rb
+++ b/lib/dry/system/rails/version.rb
@@ -3,7 +3,7 @@
 module Dry
   module System
     module Rails
-      VERSION = '0.2.0'
+      VERSION = '0.3.0'
     end
   end
 end


### PR DESCRIPTION
Update `dry-system` to 0.12.x to add support for memoization. 

Drop Support for Ruby < 2.4.