### PR TITLE
Defer accessing config until after user-provided block is evaluated

### DIFF
--- a/lib/dry/system/rails.rb
+++ b/lib/dry/system/rails.rb
@@ -32,15 +32,17 @@ module Dry
       #
       # @api private
       def self.create_container(options = {})
-        container = Class.new(Container).configure { |config|
-          config.root = ::Rails.root
-          config.system_dir = config.root.join('config/system')
-          config.update(options)
-        }
-
-        container.load_paths!('lib', 'app', 'app/models')
+        container = Class.new(Container)
 
         container.class_eval(&@container_block) if container_block
+
+        default_options = {
+          root: ::Rails.root,
+          system_dir: ::Rails.root.join('config/system'),
+        }
+        container.config.update(default_options.merge(options))
+
+        container.load_paths!('lib', 'app', 'app/models')
 
         container
       end

--- a/spec/dummy/config/initializers/container.rb
+++ b/spec/dummy/config/initializers/container.rb
@@ -3,6 +3,8 @@
 require 'dry/system/rails'
 
 Dry::System::Rails.container do
+  use :env, inferrer: -> { Rails.env.to_sym }
+
   config.auto_register << 'lib' << 'app/operations'
 
   auto_register!('app/workers') do |config|

--- a/spec/integration/container/using_plugins_spec.rb
+++ b/spec/integration/container/using_plugins_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe 'Using dry-system plugins' do
+  specify 'Using dry-system plugins (which add extra settings) inside the initializer container block' do
+    expect(Dummy::Container.env).to eq Rails.env.to_sym
+  end
+end


### PR DESCRIPTION
This makes it possible for users to e.g. use dry-system plugins that add new settings, which otherwise raises a `Dry::Configurable::AlreadyDefinedConfig` error if any config has been accessed previously.

This would be fixed anyway once we address https://github.com/dry-rb/dry-configurable/issues/70, but that's a larger piece of work, and I'd like to make dry-system-rails more flexible in the meantime.

The reason I actually needed this is because I wanted to use the dry-system `settings` component, which requires `use :env` to be added within the `Dry::System::Rails.container do ... end` block. `use :env` adds a new setting, so we need to make sure this block is evaluated as early as possible to avoid that error above.

@solnic Does this look OK to you?