### PR TITLE
Do not finalize container when Rails is running in test environment

### DIFF
--- a/lib/dry/system/rails/railtie.rb
+++ b/lib/dry/system/rails/railtie.rb
@@ -22,12 +22,7 @@ module Dry
 
           container.refresh_boot_files if reloading?
 
-          container.finalize!(freeze: freeze?)
-        end
-
-        # @api private
-        def freeze?
-          !::Rails.env.test?
+          container.finalize! unless ::Rails.env.test?
         end
 
         # @api private

--- a/spec/integration/container_spec.rb
+++ b/spec/integration/container_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'Application container' do
 
   describe '#auto_register!' do
     it 'auto-registers files based on config' do
+      Dummy::Container.finalize!(freeze: false) # force auto-registration to run (since we're in test env)
+
       mailer_worker = Dummy::Container['workers.mailer_worker']
 
       expect(mailer_worker).to be_instance_of(Workers::MailerWorker)


### PR DESCRIPTION
This reflects best practice for dry-system usage in tests. By not finalizing the container, we let it lazily load dependencies when required, which means only the minimum set of files are loaded for any given test to run.

@solnic Are you happy for me to pull in this change?

I would love to offer more thorough tests for this, but like we've discussed, this would require a complete overhaul of the testing arrangement here (i.e. so we can load/unload independent instances of the "dummy" Rails app, complete with their own configs, environments, etc.), which I would prefer not to block on just at this point.